### PR TITLE
Convert Markdown to Asciidoc, add badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
-[[localization-support-plugin]]
-= localization-support-plugin
+= Localization Support Plugin
+
 :toc: macro
 :toc-title:
 ifdef::env-github[]

--- a/README.adoc
+++ b/README.adoc
@@ -1,69 +1,75 @@
-# Localization Support Plugin
+[[localization-support-plugin]]
+= localization-support-plugin
+:toc: macro
+:toc-title:
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+image:https://img.shields.io/jenkins/plugin/v/localization-support.svg[Jenkins Plugin,link=https://plugins.jenkins.io/localization-support]
+image:https://img.shields.io/jenkins/plugin/i/localization-support.svg?color=blue[Jenkins Plugin Installs,link=https://plugins.jenkins.io/localization-support]
+image:https://ci.jenkins.io/job/Plugins/job/localization-support-plugin/job/master/badge/icon[Build Status,link=https://ci.jenkins.io/job/Plugins/job/localization-support-plugin/job/master/]
 
 Supporting infrastructure for standalone localization plugins.
 This plugin doesn't provide notable end user features, and will be installed as dependency of other plugins that use the features provided by this plugin.
 
-## Localization Overview
+toc::[]
+
+== Localization Overview
 
 Jenkins supports multiple ways to provide localized resources, and each of them has a corresponding code path in this plugin.
 
-
-### Localizer
+=== Localizer
 
 The `localizer` library looks up `Messages_??.properties` files in packages for the generated `Messages` classes.
 Support for localizing messages from the localizer library is added via the `io.jenkins.plugins.localization.support.localizer` package in this plugin.
 
-
-### Stapler views
+=== Stapler views
 
 Stapler views look up `viewname_??.properties` files in directories with the same name as the view.
 `io.jenkins.plugins.localization.support.stapler.ResourceBundleFactoryImpl` is a `ResourceBundleFactory` that gets installed by `StaplerManager`.
 I ends up calling `LocalizationContributor#findResource(String, Class)` with a cleaned up `String` argument.
-<!-- TODO details -->
-<!-- TODO are localized views (the entire Jelly) a thing, or just resources? -->
+// TODO details
 
+// TODO are localized views (the entire Jelly) a thing, or just resources?
 
-### Descriptor#doHelp
+=== Descriptor#doHelp
 
-#### Stapler views
+==== Stapler views
 
 `Descriptor#doHelp` will serve corresponding `help.jelly` views, if they exist, and lets Stapler localize them (see above).
 
-
-#### HTML files
+==== HTML files
 
 `Descriptor#doHelp` looks up `com/acme/package/MyDescribable/help-fieldname_??.html` HTML files and serves them at `/descriptor/myDescriptorSymbol/help/fieldname`, typically corresponding to specific fields in views.
 It also supports `com/acme/package/MyDescribable/help_??.html` at `/descriptor/myDescriptorSymbol/help`.
 
 Localization support of these is accomplished through setting `MetaClassLoader#debugLoader` to a classloader that has localization plugins on its class path.
-<!-- TODO introduce a proper API for this into Stapler -->
+// TODO introduce a proper API for this into Stapler
 
-
-### Core webapp resources
+=== Core webapp resources
 
 Jenkins core exposes `war/src/main/webapp/` resource files directly packaged into the war file via `Stapler#service` invoking `#openResourcePathByLocale`.
 This in turn ends up invoking `LocaleDrivenResourceProvider#lookupResource`, an SPI implemented in Jenkins core as `MetaLocaleDrivenResourceProvider` from 2.173.
 This in turn looks up implementations of `PluginLocaleDrivenResourceProvider` in plugins.
 There is one, `PluginLocaleDrivenResourceProviderImpl` in `localization-support`.
 
-
-### Plugin webapp resources
+=== Plugin webapp resources
 
 Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic` at `/plugin/namehere/` invoking `StaplerResponse#serveLocalizedFile`.
 This calls `#selectResourceByLocale` which ends up invoking `LocaleDrivenResourceProvider#lookupResource`.
 See the previous section for further details.
 
-
-
-## Administrative Monitor
+== Administrative Monitor
 
 The only user feature exposed by this plugin is an administrative monitor that complains when an incompatibility is detected.
 Some of the mechanisms used to provide localized resources from implementing plugins are exclusive, and other plugins interfering with that would prevent this plugin from working.
 If such a case is discovered, the administrative monitor informs users about the problem.
 
-
-
-## Expected Layout
+== Expected Layout
 
 Implementing plugins need to provide the localized resources in the same general directory layout as they would be placed in core and individual plugins.
-

--- a/README.md
+++ b/README.md
@@ -1,72 +1,55 @@
-= Localization Support Plugin
-
-:toc: macro
-:toc-title:
-ifdef::env-github[]
-:tip-caption: :bulb:
-:note-caption: :information_source:
-:important-caption: :heavy_exclamation_mark:
-:caution-caption: :fire:
-:warning-caption: :warning:
-endif::[]
-
+# Localization Support Plugin
 
 Supporting infrastructure for standalone localization plugins.
 This plugin doesn't provide notable end user features, and will be installed as dependency of other plugins that use the features provided by this plugin.
 
-toc::[]
-
-== Localization Overview
+## Localization Overview
 
 Jenkins supports multiple ways to provide localized resources, and each of them has a corresponding code path in this plugin.
 
-=== Localizer
+### Localizer
 
 The `localizer` library looks up `Messages_??.properties` files in packages for the generated `Messages` classes.
 Support for localizing messages from the localizer library is added via the `io.jenkins.plugins.localization.support.localizer` package in this plugin.
 
-=== Stapler views
+### Stapler views
 
 Stapler views look up `viewname_??.properties` files in directories with the same name as the view.
 `io.jenkins.plugins.localization.support.stapler.ResourceBundleFactoryImpl` is a `ResourceBundleFactory` that gets installed by `StaplerManager`.
 I ends up calling `LocalizationContributor#findResource(String, Class)` with a cleaned up `String` argument.
-// TODO details
 
-// TODO are localized views (the entire Jelly) a thing, or just resources?
+### Descriptor#doHelp
 
-=== Descriptor#doHelp
-
-==== Stapler views
+#### Stapler views
 
 `Descriptor#doHelp` will serve corresponding `help.jelly` views, if they exist, and lets Stapler localize them (see above).
 
-==== HTML files
+#### HTML files
 
 `Descriptor#doHelp` looks up `com/acme/package/MyDescribable/help-fieldname_??.html` HTML files and serves them at `/descriptor/myDescriptorSymbol/help/fieldname`, typically corresponding to specific fields in views.
 It also supports `com/acme/package/MyDescribable/help_??.html` at `/descriptor/myDescriptorSymbol/help`.
 
 Localization support of these is accomplished through setting `MetaClassLoader#debugLoader` to a classloader that has localization plugins on its class path.
-// TODO introduce a proper API for this into Stapler
 
-=== Core webapp resources
+### Core webapp resources
 
 Jenkins core exposes `war/src/main/webapp/` resource files directly packaged into the war file via `Stapler#service` invoking `#openResourcePathByLocale`.
 This in turn ends up invoking `LocaleDrivenResourceProvider#lookupResource`, an SPI implemented in Jenkins core as `MetaLocaleDrivenResourceProvider` from 2.173.
 This in turn looks up implementations of `PluginLocaleDrivenResourceProvider` in plugins.
 There is one, `PluginLocaleDrivenResourceProviderImpl` in `localization-support`.
 
-=== Plugin webapp resources
+### Plugin webapp resources
 
 Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic` at `/plugin/namehere/` invoking `StaplerResponse#serveLocalizedFile`.
 This calls `#selectResourceByLocale` which ends up invoking `LocaleDrivenResourceProvider#lookupResource`.
 See the previous section for further details.
 
-== Administrative Monitor
+## Administrative Monitor
 
 The only user feature exposed by this plugin is an administrative monitor that complains when an incompatibility is detected.
 Some of the mechanisms used to provide localized resources from implementing plugins are exclusive, and other plugins interfering with that would prevent this plugin from working.
 If such a case is discovered, the administrative monitor informs users about the problem.
 
-== Expected Layout
+## Expected Layout
 
 Implementing plugins need to provide the localized resources in the same general directory layout as they would be placed in core and individual plugins.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Stapler views look up `viewname_??.properties` files in directories with the sam
 `io.jenkins.plugins.localization.support.stapler.ResourceBundleFactoryImpl` is a `ResourceBundleFactory` that gets installed by `StaplerManager`.
 I ends up calling `LocalizationContributor#findResource(String, Class)` with a cleaned up `String` argument.
 
+<!-- TODO details -->
+<!-- TODO are localized views (the entire Jelly) a thing, or just resources? -->
+
 ### Descriptor#doHelp
 
 #### Stapler views
@@ -30,6 +33,8 @@ I ends up calling `LocalizationContributor#findResource(String, Class)` with a c
 It also supports `com/acme/package/MyDescribable/help_??.html` at `/descriptor/myDescriptorSymbol/help`.
 
 Localization support of these is accomplished through setting `MetaClassLoader#debugLoader` to a classloader that has localization plugins on its class path.
+
+<!-- TODO introduce a proper API for this into Stapler -->
 
 ### Core webapp resources
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # Localization Support Plugin
 
 Supporting infrastructure for standalone localization plugins.
-This plugin doesn't provide notable end user features, and will be installed as dependency of other plugins that use the features provided by this plugin.
+
+This plugin doesn't provide notable end user features, and will be installed as dependency of other
+plugins that use the features provided by this plugin.
 
 ## Localization Overview
 
-Jenkins supports multiple ways to provide localized resources, and each of them has a corresponding code path in this plugin.
+Jenkins supports multiple ways to provide localized resources, and each of them has a corresponding
+code path in this plugin.
 
 ### Localizer
 
 The `localizer` library looks up `Messages_??.properties` files in packages for the generated `Messages` classes.
-Support for localizing messages from the localizer library is added via the `io.jenkins.plugins.localization.support.localizer` package in this plugin.
+Support for localizing messages from the localizer library is added via the `io.jenkins.plugins.localization.support.localizer`
+package in this plugin.
 
 ### Stapler views
 
 Stapler views look up `viewname_??.properties` files in directories with the same name as the view.
-`io.jenkins.plugins.localization.support.stapler.ResourceBundleFactoryImpl` is a `ResourceBundleFactory` that gets installed by `StaplerManager`.
-I ends up calling `LocalizationContributor#findResource(String, Class)` with a cleaned up `String` argument.
+`io.jenkins.plugins.localization.support.stapler.ResourceBundleFactoryImpl` is a `ResourceBundleFactory`
+that gets installed by `StaplerManager`. I ends up calling `LocalizationContributor#findResource(String, Class)`
+with a cleaned up `String` argument.
 
 <!-- TODO details -->
 <!-- TODO are localized views (the entire Jelly) a thing, or just resources? -->
@@ -29,32 +34,39 @@ I ends up calling `LocalizationContributor#findResource(String, Class)` with a c
 
 #### HTML files
 
-`Descriptor#doHelp` looks up `com/acme/package/MyDescribable/help-fieldname_??.html` HTML files and serves them at `/descriptor/myDescriptorSymbol/help/fieldname`, typically corresponding to specific fields in views.
+`Descriptor#doHelp` looks up `com/acme/package/MyDescribable/help-fieldname_??.html` HTML files and
+serves them at `/descriptor/myDescriptorSymbol/help/fieldname`, typically corresponding to specific fields
+in views.
+
 It also supports `com/acme/package/MyDescribable/help_??.html` at `/descriptor/myDescriptorSymbol/help`.
 
-Localization support of these is accomplished through setting `MetaClassLoader#debugLoader` to a classloader that has localization plugins on its class path.
+Localization support of these is accomplished through setting `MetaClassLoader#debugLoader` to a
+classloader that has localization plugins on its class path.
 
 <!-- TODO introduce a proper API for this into Stapler -->
 
 ### Core webapp resources
 
-Jenkins core exposes `war/src/main/webapp/` resource files directly packaged into the war file via `Stapler#service` invoking `#openResourcePathByLocale`.
-This in turn ends up invoking `LocaleDrivenResourceProvider#lookupResource`, an SPI implemented in Jenkins core as `MetaLocaleDrivenResourceProvider` from 2.173.
+Jenkins core exposes `war/src/main/webapp/` resource files directly packaged into the war file via
+`Stapler#service` invoking `#openResourcePathByLocale`. This in turn ends up invoking `LocaleDrivenResourceProvider#lookupResource`,
+an SPI implemented in Jenkins core as `MetaLocaleDrivenResourceProvider` from 2.173.
 This in turn looks up implementations of `PluginLocaleDrivenResourceProvider` in plugins.
 There is one, `PluginLocaleDrivenResourceProviderImpl` in `localization-support`.
 
 ### Plugin webapp resources
 
-Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic` at `/plugin/namehere/` invoking `StaplerResponse#serveLocalizedFile`.
-This calls `#selectResourceByLocale` which ends up invoking `LocaleDrivenResourceProvider#lookupResource`.
-See the previous section for further details.
+Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic`
+at `/plugin/namehere/`  invoking `StaplerResponse#serveLocalizedFile`. This calls `#selectResourceByLocale`
+which ends up invoking `LocaleDrivenResourceProvider#lookupResource`. See the previous section for further details.
 
 ## Administrative Monitor
 
-The only user feature exposed by this plugin is an administrative monitor that complains when an incompatibility is detected.
-Some of the mechanisms used to provide localized resources from implementing plugins are exclusive, and other plugins interfering with that would prevent this plugin from working.
-If such a case is discovered, the administrative monitor informs users about the problem.
+The only user feature exposed by this plugin is an administrative monitor that complains when an incompatibility
+is detected. Some of the mechanisms used to provide localized resources from implementing plugins are
+exclusive, and other plugins interfering with that would prevent this plugin from working. If such a
+case is discovered, the administrative monitor informs users about the problem.
 
 ## Expected Layout
 
-Implementing plugins need to provide the localized resources in the same general directory layout as they would be placed in core and individual plugins.
+Implementing plugins need to provide the localized resources in the same general directory layout as
+they would be placed in core and individual plugins.

--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,0 +1,1 @@
+mvn_version=3.6.3

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
 
     <name>Localization Support Plugin</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Localization+Support+Plugin</url>
+    <url>https://github.com/jenkinsci/localization-support-plugin</url>
 
     <properties>
         <revision>1.2.1</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <revision>1.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249.3</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>4.12</version>
         <relativePath />
     </parent>
 
@@ -17,9 +17,9 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Localization+Support+Plugin</url>
 
     <properties>
-        <revision>1.2</revision>
+        <revision>1.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.173</jenkins.version>
+        <jenkins.version>2.249.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
This is part of the effort to make documentation more attractive to users and developers. I think the agreed upon standard for Jenkins is moving towards Asciidoc instead of Markdown.