### PR TITLE
fix translation missing value of Messages_??.properties

### DIFF
--- a/src/main/java/io/jenkins/plugins/localization/support/localizer/LocalizerManager.java
+++ b/src/main/java/io/jenkins/plugins/localization/support/localizer/LocalizerManager.java
@@ -47,7 +47,7 @@ public class LocalizerManager extends ExtensionListListener {
         ResourceBundleHolder.clearCache();
     }
 
-    @Initializer(after = InitMilestone.JOB_LOADED)
+    @Initializer(after = InitMilestone.PLUGINS_STARTED)
     public static void initialize() {
         ResourceProvider.setProvider(new ResourceProviderImpl());
         ResourceBundleHolder.clearCache();


### PR DESCRIPTION
For example, on the home page "New Item",
the normal display of complete Chinese is "新建任务",
and when it is not normal, it will display "新建Item"
"New" is from sidepanel.properties file:
  NewJob=New {0}
"Item" is from Messages.properties file.

Signed-off-by: bright.ma <bright.ma@blackshark.com>

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
