### PR TITLE
Require Java 11, test with Java 17 and Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,10 @@
-// https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.78</version>
         <relativePath />
     </parent>
 
@@ -19,7 +19,7 @@
     <properties>
         <revision>1.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
## Require Java 11, test with Java 17 and 21

Jenkins 2.401.3 is the oldest version recommended by https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

57% of installations of the most recent release of the plugin are already running 2.401.1 or newer.

### Testing done

Automated tests pass.  No other validation performed.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
