### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
     <extension>
         <groupId>io.jenkins.tools.incrementals</groupId>
         <artifactId>git-changelist-maven-extension</artifactId>
-        <version>1.0-beta-7</version>
+        <version>1.8</version>
     </extension>
 </extensions>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There is one, `PluginLocaleDrivenResourceProviderImpl` in `localization-support`
 
 ### Plugin webapp resources
 
-Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic` at `/plugin/namehere/` invoking `StaplerResponse#serveLocalizedFile`.
+Plugins expose `src/main/webapp/` resource files directly packaged into the jpi file via `Plugin#doDynamic` at `/plugin/namehere/` invoking `StaplerResponse2#serveLocalizedFile`.
 This calls `#selectResourceByLocale` which ends up invoking `LocaleDrivenResourceProvider#lookupResource`.
 See the previous section for further details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.78</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
@@ -19,7 +19,8 @@
     <properties>
         <revision>1.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.479.1</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
     <licenses>
@@ -38,9 +39,9 @@
     </dependencies>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.7</version>
+        <version>5.17</version>
         <relativePath />
     </parent>
 
@@ -19,7 +19,7 @@
     <properties>
         <revision>1.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.479.1</jenkins.version>
+        <jenkins.version>2.479.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/src/main/java/io/jenkins/plugins/localization/support/LocalizationMonitor.java
+++ b/src/main/java/io/jenkins/plugins/localization/support/LocalizationMonitor.java
@@ -33,7 +33,7 @@ import hudson.model.AdministrativeMonitor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebApp;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.kohsuke.stapler.jelly.JellyFacet;
@@ -60,7 +60,7 @@ public class LocalizationMonitor extends AdministrativeMonitor {
     public boolean isActivated() {
         Jenkins jenkins = Jenkins.get();
 
-        WebApp webContext = WebApp.get(jenkins.servletContext);
+        WebApp webContext = WebApp.get(jenkins.getServletContext());
         JellyFacet facet = webContext.getFacet(JellyFacet.class);
         ResourceBundleFactory factory = facet.resourceBundleFactory;
 
@@ -72,7 +72,7 @@ public class LocalizationMonitor extends AdministrativeMonitor {
 
     @RequirePOST
     @Restricted(NoExternalUse.class)
-    public HttpResponse doAct(StaplerRequest req) throws IOException {
+    public HttpResponse doAct(StaplerRequest2 req) throws IOException {
         if (req.hasParameter("no")) {
             disable(true);
             return HttpResponses.redirectViaContextPath("/manage");

--- a/src/main/java/io/jenkins/plugins/localization/support/stapler/StaplerManager.java
+++ b/src/main/java/io/jenkins/plugins/localization/support/stapler/StaplerManager.java
@@ -43,7 +43,7 @@ public class StaplerManager extends ExtensionListListener {
     @Initializer
     public static void initialize() {
         { // resources for Jelly files
-            WebApp webApp = WebApp.get(Jenkins.get().servletContext);
+            WebApp webApp = WebApp.get(Jenkins.get().getServletContext());
 
             // Override where the Jelly views look for resource bundles
             JellyFacet facet = webApp.getFacet(JellyFacet.class);


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

Closes #11

### Testing done

`mvn clean verify`